### PR TITLE
CRM-168: Donation History by GL Account (Summary) fix

### DIFF
--- a/chreports.php
+++ b/chreports.php
@@ -305,9 +305,7 @@ function chreports_civicrm_alterReportVar($varType, &$var, &$object) {
           if ($column == 'civicrm_contribution_contribution_page_id') {
             $contributionPages = CRM_Contribute_PseudoConstant::contributionPage();
             foreach ($var as $rowNum => $row) {
-              if (!in_array($var[$rowNum]['civicrm_contribution_contribution_page_id'], $entityTypes)) {
-                $var[$rowNum]['civicrm_contribution_contribution_page_id'] = CRM_Utils_Array::value($row['civicrm_contribution_contribution_page_id'], $contributionPages);
-              }
+              $var[$rowNum]['civicrm_contribution_contribution_page_id'] = CRM_Utils_Array::value($row['civicrm_contribution_contribution_page_id'], $contributionPages, $row['civicrm_contribution_contribution_page_id']);
             }
           }
         }

--- a/chreports.php
+++ b/chreports.php
@@ -191,7 +191,7 @@ function chreports_civicrm_alterReportVar($varType, &$var, &$object) {
         $var['civicrm_contact']['fields']['financial_account'] = ['title' => ts('Financial Account'), 'dbAlias' => 'fa.name'];
         $var['civicrm_contact']['group_bys']['financial_account'] = ['title' => ts('Financial Account'), 'dbAlias' => 'fa.name'];
         $var['civicrm_contact']['filters']['financial_account'] = [
-          'title' => ts('Financial Account'),
+          'title' => ts('GL Account'),
           'type' => CRM_Utils_Type::T_STRING,
           'operatorType' => CRM_Report_Form::OP_MULTISELECT,
           'options' => CRM_Contribute_PseudoConstant::financialAccount(),
@@ -317,7 +317,9 @@ function chreports_civicrm_alterReportVar($varType, &$var, &$object) {
         if (end($var) != 'grandtotal') {
           $lastArray = $var['grandtotal'];
           unset($var['grandtotal']);
-          $var['grandtotal'] = $lastArray;
+          if (!empty($var)) {
+            $var['grandtotal'] = $lastArray;
+          }
         }
       }
     }


### PR DESCRIPTION
This PR includes the following improvements/fixes: 
1. Changed the FROM clause of extended contribution summary report template
2. Overridden ```statistics()``` fn of core summary report to calculate the total count and amount from financial_trxn table instead of civicrm_contribution table
3. Removed any query modification to core contribution summary report in alterReportVar hook. 
4. Financial Account as display columns, Grouping and Filter for report now exclusively available to Extended Summary report template.  