### PR TITLE
CRM-168: Remove Grand total row from extended summary report as we are already showing total under stats section

### DIFF
--- a/CRM/Chreports/Form/Report/ExtendSummary.php
+++ b/CRM/Chreports/Form/Report/ExtendSummary.php
@@ -3,6 +3,12 @@ use CRM_Chreports_ExtensionUtil as E;
 
 class CRM_Chreports_Form_Report_ExtendSummary extends CRM_Report_Form_Contribute_Summary {
 
+  public function groupBy() {
+    parent::groupBy();
+    $this->_groupBy = str_replace($this->_rollup, '', $this->_groupBy);
+    $this->_rollup = '';
+  }
+
   public function from($entity = NULL) {
     parent::from($entity);
     if (!strstr($this->_from, 'civicrm_line_item li') && array_key_exists('financial_account', $this->_params['group_bys'])) {


### PR DESCRIPTION
Before
---------
<img width="1272" alt="Screen Shot 2020-03-13 at 1 18 28 PM" src="https://user-images.githubusercontent.com/3735621/76600563-2ceec280-652d-11ea-9c65-c766dce98195.png">


After
---------
<img width="1287" alt="Screen Shot 2020-03-13 at 1 17 38 PM" src="https://user-images.githubusercontent.com/3735621/76600496-134d7b00-652d-11ea-87d1-c2db776aeec2.png">
