### PR TITLE
CRM-819: [Reports] Discrepancy on Contribution History by Fund/CH Fund reports

### DIFF
--- a/CRM/Chreports/Form/Report/ExtendSummary.php
+++ b/CRM/Chreports/Form/Report/ExtendSummary.php
@@ -65,13 +65,14 @@ class CRM_Chreports_Form_Report_ExtendSummary extends CRM_Report_Form_Contribute
     // replace the core select columns to use respective columns
     $this->_select = str_replace("SUM({$this->_aliases['civicrm_contribution']}.total_amount)", "SUM(eft_fi.amount)", $this->_select);
     $this->_select = str_replace("COUNT({$this->_aliases['civicrm_contribution']}.total_amount)", "COUNT(DISTINCT {$this->_aliases['civicrm_contribution']}.id)", $this->_select);
-
+    //CRM-819 To resolve data discrepancy where discrepancy contributions not having a GL account (financial account) defined
+    //changing condition from "INNER" join to "LEFT" join
     $this->_from .= "
     INNER JOIN civicrm_entity_financial_trxn eft_c ON contribution_civireport.id = eft_c.entity_id AND eft_c.entity_table = 'civicrm_contribution'
     INNER JOIN civicrm_financial_trxn ft ON eft_c.financial_trxn_id = ft.id
     INNER JOIN civicrm_entity_financial_trxn eft_fi ON ft.id = eft_fi.financial_trxn_id AND eft_fi.entity_table = 'civicrm_financial_item'
     INNER JOIN civicrm_financial_item fi ON eft_fi.entity_id = fi.id AND fi.entity_table = 'civicrm_line_item'
-    INNER JOIN civicrm_financial_account fa ON fi.financial_account_id = fa.id
+    LEFT JOIN civicrm_financial_account fa ON fi.financial_account_id = fa.id
     ";
     $tableName = E::getTableNameByName('Campaign_Information');
     if (!empty($tableName)) {


### PR DESCRIPTION
Contribution History by Fund (summary) report should display all contributions which has **Fund value** set irrespective of **GL account** value. In the earlier query, there was an inner join which was checking for **financial_account_id**  (GL account) value as well, if contribution has **NULL**  financial_account_id  it was not including that contribution in the report. We have changed that join condition to **LEFT** join, now Contribution History by Fund (Summary) and (Detailed) are having same number of contribution and Fund totals.