### PR TITLE
CRM-2199:Reports are not getting exported as CSV when too many columns are selected

### DIFF
--- a/chreports.php
+++ b/chreports.php
@@ -148,14 +148,17 @@ function chreports_civicrm_buildForm($formName, &$form) {
     $selectedColumnFields = count($columnFields);
     if(isset($selectedColumnFields) && $selectedColumnFields > 10) {
       if (array_key_exists('task', $form->_elementIndex)) {
-        $optionsField = $form->getElement('task')->_options;
-        foreach($optionsField as $key=>$value) {
-          foreach($value['attr'] as $k=>$v) {
-            if($v === 'report_instance.print') {
-              unset($form->getElement('task')->_options[$key]);
-            }
-          }
-        }
+        //CRM-2199 Hiding "Print Report" option rather than unsetting, unsetting that option is impacting "Export as CSV" option as well
+        CRM_Core_Resources::singleton()->addScript(
+          "CRM.$(function($) {
+            $('#task-section option').each(function() {
+              var actionOptions = $(this).val();
+              if(actionOptions === 'report_instance.print'){
+                $(this).closest('option').remove();
+              }
+            });
+          });"
+        );
       }
     }
   }

--- a/chreports.php
+++ b/chreports.php
@@ -136,32 +136,6 @@ function chreports_civicrm_entityTypes(&$entityTypes) {
 
 function chreports_civicrm_buildForm($formName, &$form) {
   $isRefactored = $formName == "CRM_Chreports_Form_Report_ExtendSummary" || $formName == "CRM_Chreports_Form_Report_ExtendedDetail";
-  
-  if ($isRefactored || in_array($formName, [
-    'CRM_Report_Form_Contact_Summary'
-  ])) {
-    //CRM-799 To solve the issue of report columns being cut-off, limit the "Print report" function 
-    //to only be available when the selected report has 10 columns or less. If more than 10 columns are selected, hide "Print report" function
-    // @TODO this doesn't work for all scenarios, and is more a temp hack rather than a fix
-    $columnFields = isset($form->getVar('_submitValues')['fields']) ? $form->getVar('_submitValues')['fields'] : 
-      (isset($form->getVar('_params')['fields']) ? $form->getVar('_params')['fields'] : []);
-    $selectedColumnFields = count($columnFields);
-    if(isset($selectedColumnFields) && $selectedColumnFields > 10) {
-      if (array_key_exists('task', $form->_elementIndex)) {
-        //CRM-2199 Hiding "Print Report" option rather than unsetting, unsetting that option is impacting "Export as CSV" option as well
-        CRM_Core_Resources::singleton()->addScript(
-          "CRM.$(function($) {
-            $('#task-section option').each(function() {
-              var actionOptions = $(this).val();
-              if(actionOptions === 'report_instance.print'){
-                $(this).closest('option').remove();
-              }
-            });
-          });"
-        );
-      }
-    }
-  }
 
   if ($isRefactored) {
     //default pre-select the column and group by


### PR DESCRIPTION
Instead of unsetting "Print Report" option from task , we are hiding that option using jQuery because unsetting "Print Report"  is impacting "Export as CSV" option as well for charity admins. 

This feature was working fine for super admin because in task list super admins have "Save" option but that option is not there for charity admins. That is why if report has more than 10 resulting columns, with unsettled "Print Report" option charity admin was not able to export CSV.